### PR TITLE
[SGP-2425] Allow specifying of serializer keyword arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,23 @@ version: 2
 
 jobs:
   run-tests:
+    docker:
+      - image: circleci/python:latest
     steps:
       - run:
-        name: Install Python requirements
-        command: |
-            pip install virtualenv
-            virtualenv ~/venv
-            source ~/venv/bin/activate
-            pip install -r requirements.txt
-            pip install Django==1.8.19
-            pip install djangorestframework==3.2.5
+          name: Install Python requirements
+          command: |
+              pip install virtualenv
+              virtualenv ~/venv
+              source ~/venv/bin/activate
+              pip install -r requirements.txt
+              pip install Django==1.8.19
+              pip install djangorestframework==3.2.5
       - run:
-        name: Run Python tests
-        command: |
-            source ~/venv/bin/activate
-            ./manage.py test --settings=test_settings
+          name: Run Python tests
+          command: |
+              source ~/venv/bin/activate
+              ./manage.py test --settings=test_settings
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+
+jobs:
+  run-tests:
+    steps:
+      - run:
+        name: Install Python requirements
+        command: |
+            pip install virtualenv
+            virtualenv ~/venv
+            source ~/venv/bin/activate
+            pip install -r requirements.txt
+            pip install Django==1.8.19
+            pip install djangorestframework==3.2.5
+      - run:
+        name: Run Python tests
+        command: |
+            source ~/venv/bin/activate
+            ./manage.py test --settings=test_settings
+
+workflows:
+  version: 2
+  build-and-tests:
+    jobs:
+      - run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: circleci/python:latest
     steps:
+      - checkout
       - run:
           name: Install Python requirements
           command: |

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -172,14 +172,28 @@ class MultipleModelMixin(object):
 
 class Query(object):
 
-    def __init__(self, queryset, serializer, label=None, filter_fn=None, ):
+    def __init__(
+        self,
+        queryset,
+        serializer,
+        label=None,
+        filter_fn=None,
+        serializer_kwargs=None
+    ):
         self.queryset = queryset
         self.serializer = serializer
         self.filter_fn = filter_fn
         self.label = label
+        self.serializer_kwargs = serializer_kwargs
+
+    @classmethod
+    def new_from_dict(cls, query_serializer_info):
+        pass
 
     @classmethod
     def new_from_tuple(cls, tuple_):
+        if isinstance(tuple_, dict):
+            return cls.new_from_dict(tuple_)
         try:
             queryset, serializer, label = tuple_
         except ValueError:

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -213,6 +213,7 @@ class Query(object):
             {"label", "queryset", "serializer", "serializer_kwargs"}
         )
         query = Query(**query_serializer_info)
+        return query
 
     @classmethod
     def new_from_tuple(cls, tuple_):

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -103,7 +103,12 @@ class MultipleModelMixin(object):
 
             # Run the paired serializer
             context = self.get_serializer_context()
-            data = query.serializer(queryset, many=True, context=context).data
+            data = query.serializer(
+                queryset,
+                many=True,
+                context=context,
+                **query.serializer_kwargs
+            ).data
 
             results = self.format_data(data, query, results)
 
@@ -200,7 +205,7 @@ class Query(object):
         self.serializer = serializer
         self.filter_fn = filter_fn
         self.label = label
-        self.serializer_kwargs = serializer_kwargs
+        self.serializer_kwargs = serializer_kwargs if serializer_kwargs else {}
 
     @classmethod
     def new_from_dict(cls, query_serializer_info):

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -25,6 +25,22 @@ class MultipleModelMixin(object):
             .....
     ]
 
+    You can also specify a dictionary of keyword arguments for the serializer.
+    In that case, use a dict instead of a tuple. Example:
+
+    queryList = [
+            (querysetA, serializerA, 'labelA'),
+            (querysetB, serializerB, 'labelB'),
+            {
+                "queryset": querysetC,
+                "serializer="serializerC",
+                "serializer_kwargs": {"fields_to_include": ["one", "two"]}
+            },
+            .....
+    ]
+
+
+
     """
 
     objectify = False
@@ -188,7 +204,10 @@ class Query(object):
 
     @classmethod
     def new_from_dict(cls, query_serializer_info):
-        pass
+        assert set(query_serializer_info.keys()).issubset(
+            {"label", "queryset", "serializer", "serializer_kwargs"}
+        )
+        query = Query(**query_serializer_info)
 
     @classmethod
     def new_from_tuple(cls, tuple_):

--- a/drf_multiple_model/mixins.py
+++ b/drf_multiple_model/mixins.py
@@ -33,7 +33,7 @@ class MultipleModelMixin(object):
             (querysetB, serializerB, 'labelB'),
             {
                 "queryset": querysetC,
-                "serializer="serializerC",
+                "serializer": serializerC,
                 "serializer_kwargs": {"fields_to_include": ["one", "two"]}
             },
             .....
@@ -81,7 +81,8 @@ class MultipleModelMixin(object):
         """
         Wrapper for pagination function.
 
-        By default it just calls paginate_queryset, but can be overwritten for custom functionality
+        By default it just calls paginate_queryset, but can be
+        overwritten for custom functionality
         """
         return self.paginate_queryset(queryList)
 
@@ -90,7 +91,8 @@ class MultipleModelMixin(object):
 
         results = {} if self.objectify else []
 
-        # Iterate through the queryList, run each queryset and serialize the data
+        # Iterate through the queryList, run each queryset and
+        # serialize the data
         for query in queryList:
             if not isinstance(query, Query):
                 query = Query.new_from_tuple(query)
@@ -122,13 +124,13 @@ class MultipleModelMixin(object):
             if page is not None:
                 return self.get_paginated_response(page)
 
-
         if request.accepted_renderer.format == 'html':
             return Response({'data': results})
 
         return Response(results)
 
-    # formats the serialized data based on various view properties (e.g. flat=True)
+    # formats the serialized data based on various view properties
+    # (e.g. flat=True)
     def format_data(self, new_data, query, results):
         # Get the label, unless add_model_type is note set
         label = None
@@ -139,7 +141,9 @@ class MultipleModelMixin(object):
                 label = query.queryset.model.__name__.lower()
 
         if self.flat and self.objectify:
-            raise RuntimeError("Cannot objectify data with flat=True. Try to use flat=False")
+            raise RuntimeError(
+                "Cannot objectify data with flat=True. Try to use flat=False"
+            )
 
         # if flat=True, Organize the data in a flat manner
         elif self.flat:
@@ -151,9 +155,12 @@ class MultipleModelMixin(object):
         # if objectify=True, Organize the data in an object
         elif self.objectify:
             if not label:
-                raise RuntimeError("Cannot objectify data. Try to use objectify=False")
+                raise RuntimeError(
+                    "Cannot objectify data. Try to use objectify=False"
+                )
 
-            # Get paginated data for selected label, if paginating_label is provided
+            # Get paginated data for selected label, if paginating_label
+            # is provided.
             if label == self.paginating_label:
                 paginated_results = self.get_paginated_response(new_data).data
                 paginated_results.pop("results", None)


### PR DESCRIPTION
This PR updates DjangoRestMultipleModels to allow us to specify (and pass along) keyword arguments for the serializer. 

So, we can do something like this now:

```
        ignore_fields = [
            "upcoming_events",
            "sponsors",
            "partners",
            "introduction"
        ]
        query_list = (
            {
                "queryset": newsletter_queryset,
                "serializer": NewsletterSerializer,
                "serializer_kwargs": {"ignore_fields": ignore_fields}
            },
            {
                "queryset": trigger_schedule_queryset,
                "serializer": EmailCampaignSerializer
            }
        )
```